### PR TITLE
Fix logic to match `GetNetworkProtocolsResponse`

### DIFF
--- a/lib/Repository/ParseData.dart
+++ b/lib/Repository/ParseData.dart
@@ -210,7 +210,7 @@ List<NetworkProtocol>parseGetNetworkProtocols(String info){
     List<String> ports = port.split(',');
     List<NetworkProtocol> list = [];
     for (int i= 0 ; i< names.length ; i++){
-       NetworkProtocol npObject = NetworkProtocol(names[i], (enableds[i] == 'true'), int.parse(ports[i]));
+       NetworkProtocol npObject = NetworkProtocol(names[i].trim(), (enableds[i].trim() == 'true'), int.parse(ports[i]));
        list.add(npObject);
     }
     return list;

--- a/test/test.dart
+++ b/test/test.dart
@@ -42,10 +42,10 @@ void main() {
     expect(output[0].name, equals('HTTP'));
     expect(output[0].enabled, equals(true));
     expect(output[0].port, equals(80));
-    expect(output[1].name, equals(' RTSP'));
-    expect(output[1].enabled, equals(false));
+    expect(output[1].name, equals('RTSP'));
+    expect(output[1].enabled, equals(true));
     expect(output[1].port, equals(554));
-    expect(output[2].name, equals(' HTTPS'));
+    expect(output[2].name, equals('HTTPS'));
     expect(output[2].enabled, equals(false));
     expect(output[2].port, equals(443));
   });


### PR DESCRIPTION
Ensure that the `NetworkProtocol` `name` has no extraneous spaces,
and that `enabled` correctly matches the returned value